### PR TITLE
Components: Added types for `componentRef` Button's prop

### DIFF
--- a/packages/components/index.d.ts
+++ b/packages/components/index.d.ts
@@ -89,6 +89,7 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   gaEventName?: string;
   component?: (props: any) => JSX.Element;
   full?: boolean;
+  componentRef?: React.Ref<HTMLElement>;
 }
 
 interface BoxProps extends React.HTMLAttributes<HTMLDivElement> {


### PR DESCRIPTION
Fix #114