### PR TITLE
Components: Make "children" prop not required in Typography and Tooltip

### DIFF
--- a/packages/components/index.d.ts
+++ b/packages/components/index.d.ts
@@ -506,7 +506,7 @@ interface AutocompleteProps<T> extends Omit<React.HTMLAttributes<HTMLDivElement>
 
 interface TooltipProps extends React.HTMLAttributes<HTMLDivElement>, Omit<TooltipPopperProps, 'referenceElement' | 'children' | 'open'> {
   children: React.ReactNode;
-  content: React.ReactNode;
+  content?: React.ReactNode;
   action?: 'click' | 'hover' | 'focus' | 'none';
   component?: string;
   ref?: React.Ref<HTMLElement>;
@@ -522,7 +522,7 @@ interface TooltipProps extends React.HTMLAttributes<HTMLDivElement>, Omit<Toolti
 
 interface TooltipPopperProps {
   open: boolean;
-  children: React.ReactNode;
+  children?: React.ReactNode;
   arrow?: boolean;
   placement?: PlacementType;
   positionFixed?: boolean;
@@ -549,7 +549,7 @@ interface TypographyBasicProps extends React.HTMLAttributes<HTMLElement> {
 }
 
 interface TypographyProps extends TypographyBasicProps {
-  children: React.ReactNode;
+  children?: React.ReactNode;
   ref?: React.Ref<HTMLElement>;
 }
 

--- a/packages/components/src/components/tooltip/tooltip.jsx
+++ b/packages/components/src/components/tooltip/tooltip.jsx
@@ -36,7 +36,7 @@ export default class Tooltip extends Component {
     /**
      * This is what will be displayed inside the tooltip.
      */
-    content: PropTypes.node.isRequired,
+    content: PropTypes.node,
     /**
      * Which action cause tooltip shown.
      */
@@ -186,6 +186,7 @@ export default class Tooltip extends Component {
     classNameTooltipContent: '',
     showDelay: 0,
     flipBoundaryElement: 'viewport',
+    content: undefined,
   }
 
   constructor(props) {

--- a/packages/components/src/components/tooltip/tooltip_popper.jsx
+++ b/packages/components/src/components/tooltip/tooltip_popper.jsx
@@ -119,10 +119,11 @@ export default class TooltipPopper extends React.Component {
       preventOverflow,
       preventFlip,
       flipBoundaryElement,
+      children,
       ...other
     } = this.props;
 
-    if (!open) {
+    if (!open || !children) {
       return null;
     }
 
@@ -168,7 +169,7 @@ TooltipPopper.propTypes = {
   /**
    * This is what will be displayed inside the popper.
    */
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   /**
    * If `true`, the popper arrow is shown.
    */
@@ -274,4 +275,5 @@ TooltipPopper.defaultProps = {
   classNameTooltipContent: '',
   showDelay: 0,
   flipBoundaryElement: 'viewport',
+  children: undefined,
 };

--- a/packages/components/src/components/typography/index.jsx
+++ b/packages/components/src/components/typography/index.jsx
@@ -76,7 +76,7 @@ Typography.propTypes = {
   /**
    * This is what will be displayed inside the button
    */
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   /**
    * Typography type
    */
@@ -120,4 +120,5 @@ Typography.defaultProps = {
   tabletType: '',
   mobileType: '',
   component: undefined,
+  children: undefined,
 };


### PR DESCRIPTION
Related to https://github.com/PeculiarVentures/peculiar-react-components/issues/122