### PR TITLE
Components: Added ability to use Typography `component` prop. Improve PropTypes validation for Tooltip component

### DIFF
--- a/packages/components/index.d.ts
+++ b/packages/components/index.d.ts
@@ -508,7 +508,7 @@ interface TooltipProps extends React.HTMLAttributes<HTMLDivElement>, Omit<Toolti
   children: React.ReactNode;
   content?: React.ReactNode;
   action?: 'click' | 'hover' | 'focus' | 'none';
-  component?: string;
+  component?: keyof React.ReactHTML;
   ref?: React.Ref<HTMLElement>;
   open?: boolean;
   onClose?: () => void;
@@ -546,6 +546,7 @@ interface TypographyBasicProps extends React.HTMLAttributes<HTMLElement> {
   color?: Color;
   align?: 'left' | 'center' | 'right' | 'auto';
   className?: string;
+  component?: keyof React.ReactHTML;
 }
 
 interface TypographyProps extends TypographyBasicProps {

--- a/packages/components/src/components/tooltip/tooltip.jsx
+++ b/packages/components/src/components/tooltip/tooltip.jsx
@@ -77,7 +77,7 @@ export default class Tooltip extends Component {
     /**
      * Parent component for tooltip and reference element.
      */
-    component: PropTypes.string,
+    component: PropTypes.elementType,
     /**
      * Padding from tooltip to reference element in `px`.
      */


### PR DESCRIPTION
Related to #122

In #126 was added a prop `component` that allows using `Typography` component as any HTML tag. But for some reason types were not updated and the typescript doesn't see `component` prop. This PR fix it. Also improved PropTypes validation for Tooltip component.